### PR TITLE
feat: Initial MCP server, Docker config, and quickstart guide

### DIFF
--- a/MCP_QUICKSTART.md
+++ b/MCP_QUICKSTART.md
@@ -1,0 +1,95 @@
+# GHOST DMPM - MCP Quick Reference
+
+## For AI Assistants (Copy this to your context)
+
+### Connection
+- URL: `ws://localhost:8765`
+- Token: `ghost-mcp-2024`
+
+### Top 5 Queries (Example Commands)
+
+These are example JSON payloads you would send to the MCP server via WebSocket.
+
+1.  **List anonymous carriers (Top 10)**
+    ```json
+    {
+      "token": "ghost-mcp-2024",
+      "command": "query_database",
+      "payload": {
+        "query_type": "get_top_mvnos",
+        "limit": 10
+      }
+    }
+    ```
+    *MCP Function: `query_database` (internally uses `ghost_db.get_top_mvnos`)*
+
+2.  **Check specific carrier (e.g., Mint Mobile)**
+    ```json
+    {
+      "token": "ghost-mcp-2024",
+      "command": "query_database",
+      "payload": {
+        "query_type": "get_mvno_details",
+        "mvno_name": "Mint Mobile"
+      }
+    }
+    ```
+    *MCP Function: `query_database` (internally could use a new `ghost_db` method or search existing policies)*
+    *(Note: `get_mvno_details` is an assumed function for this example; actual implementation might vary. The prompt's `search_mvno("Mint Mobile")` implies a direct search function which can be mapped to this.)*
+
+3.  **Policy changes this week (last 7 days)**
+    ```json
+    {
+      "token": "ghost-mcp-2024",
+      "command": "query_database",
+      "payload": {
+        "query_type": "get_recent_changes",
+        "days": 7
+      }
+    }
+    ```
+    *MCP Function: `query_database` (internally uses `ghost_db.get_recent_changes`)*
+
+4.  **Predict changes (30-day forecast - conceptual)**
+    *(This functionality is listed in the quickstart but not part of the initial 5 core modules. It's likely a future enhancement for Phase 3 or beyond. Placeholder command shown.)*
+    ```json
+    {
+      "token": "ghost-mcp-2024",
+      "command": "predict_changes",
+      "payload": {
+        "scope": "all",
+        "days_ahead": 30
+      }
+    }
+    ```
+    *MCP Function: `predict_changes` (conceptual advanced feature)*
+
+5.  **Generate OPSEC strategy (low risk - conceptual)**
+    *(This functionality is also likely a future enhancement. Placeholder command shown.)*
+    ```json
+    {
+      "token": "ghost-mcp-2024",
+      "command": "generate_acquisition_plan",
+      "payload": {
+        "risk_profile": "low",
+        "sim_cards_needed": 1
+      }
+    }
+    ```
+    *MCP Function: `generate_acquisition_plan` (conceptual advanced feature)*
+
+### Natural Language Examples (To be processed by AI client into MCP commands)
+
+These are illustrative examples of what an AI might ask. The `mcp_client.py` (to be built later) would translate these into the structured JSON commands above.
+
+- "Which carriers don't check ID?"
+  *(Likely maps to `query_database` with `get_top_mvnos` or a specific filter)*
+- "Has Cricket's policy changed?"
+  *(Likely maps to `query_database` with `get_recent_changes` filtered by "Cricket" or `get_mvno_details` for "Cricket")*
+- "Best carrier for burner phone?"
+  *(Likely maps to `query_database` with `get_top_mvnos` and specific parameters)*
+- "Alert me to policy tightening."
+  *(This implies a persistent monitoring setup, potentially a new MCP command or a client-side feature built on `get_recent_changes`.)*
+
+---
+**Note**: The MCP server functions `predict_changes` and `generate_acquisition_plan` are listed as per the prompt's quick start guide but are considered advanced features not part of the initial 5 core GHOST module integrations. Their command structures are conceptual. The primary focus for initial implementation will be commands related to config, crawl, parse, report, and database queries.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,24 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  ghost-mcp:
+    build: .
+    container_name: ghost-mcp-server
+    ports:
+      - "8765:8765"
+    environment:
+      - MCP_AUTH_TOKEN=ghost-mcp-2024
+      - PYTHONUNBUFFERED=1 # For immediate logging output
+    volumes:
+      - ./data:/app/data # For db access by MCP server if needed
+      - ./logs:/app/logs # For MCP server logs
+      - ./reports:/app/reports # For report access by MCP server
+      - ./test_output:/app/test_output # For parsed/raw data access
+      - ./config:/app/config # For config access
+    # Ensure ghost-dmpm (which might create initial db/config) is up,
+    # though MCP server is largely independent for now.
+    # depends_on:
+    #   - ghost-dmpm
+    command: ["python", "ghost_mcp_server.py"]
+    restart: unless-stopped

--- a/ghost_mcp_server.py
+++ b/ghost_mcp_server.py
@@ -1,0 +1,135 @@
+import asyncio
+import websockets
+import json
+import logging
+from functools import wraps
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler("logs/ghost_mcp_server.log"),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger("GhostMCPServer")
+
+MCP_AUTH_TOKEN = "ghost-mcp-2024"  # As specified in docker-compose and quickstart
+
+# --- Authentication Decorator ---
+def authenticate(func):
+    @wraps(func)
+    async def wrapper(websocket, message):
+        if "token" not in message or message["token"] != MCP_AUTH_TOKEN:
+            await websocket.send(json.dumps({"error": "Authentication failed", "success": False}))
+            logger.warning(f"Authentication failed for command {message.get('command')} from {websocket.remote_address}")
+            return
+        logger.info(f"Authenticated command {message.get('command')} from {websocket.remote_address}")
+        return await func(websocket, message)
+    return wrapper
+
+# --- MCP Tool Implementations (Placeholders) ---
+
+@authenticate
+async def get_config_handler(websocket, message):
+    # Placeholder: Implement interaction with ghost_config.py
+    logger.info("Executing get_config command")
+    # Example: from ghost_config import GhostConfig; config = GhostConfig(); data = config.config
+    await websocket.send(json.dumps({"command": "get_config", "status": "success", "data": {"message": "get_config not fully implemented yet"}}))
+
+@authenticate
+async def run_crawl_handler(websocket, message):
+    # Placeholder: Implement interaction with ghost_crawler.py
+    logger.info("Executing run_crawl command")
+    # Example: from ghost_crawler import GhostCrawler; from ghost_config import GhostConfig
+    # config = GhostConfig(); crawler = GhostCrawler(config); results = crawler.search_mvno_policies()
+    await websocket.send(json.dumps({"command": "run_crawl", "status": "success", "data": {"message": "run_crawl not fully implemented yet"}}))
+
+@authenticate
+async def parse_data_handler(websocket, message):
+    # Placeholder: Implement interaction with ghost_parser.py
+    # This might need input data (e.g., path to raw crawl results)
+    logger.info("Executing parse_data command")
+    # Example: from ghost_parser import GhostParser; from ghost_config import GhostConfig
+    # config = GhostConfig(); parser = GhostParser(config);
+    # search_results_file = message.get("payload", {}).get("search_results_file")
+    # if search_results_file: parsed_data = parser.parse_results(json.load(open(search_results_file)))
+    await websocket.send(json.dumps({"command": "parse_data", "status": "success", "data": {"message": "parse_data not fully implemented yet"}}))
+
+@authenticate
+async def get_report_handler(websocket, message):
+    # Placeholder: Implement interaction with ghost_reporter.py
+    logger.info("Executing get_report command")
+    # Example: from ghost_reporter import GhostReporter; from ghost_config import GhostConfig
+    # config = GhostConfig(); reporter = GhostReporter(config); report = reporter.generate_intelligence_brief()
+    await websocket.send(json.dumps({"command": "get_report", "status": "success", "data": {"message": "get_report not fully implemented yet"}}))
+
+@authenticate
+async def query_database_handler(websocket, message):
+    # Placeholder: Implement interaction with ghost_db.py
+    # This will need specific query parameters, e.g., mvno_name, limit, days
+    logger.info("Executing query_database command")
+    # Example: from ghost_db import GhostDatabase; from ghost_config import GhostConfig
+    # config = GhostConfig(); db = GhostDatabase(config);
+    # query_type = message.get("payload", {}).get("query_type")
+    # if query_type == "top_mvnos": data = db.get_top_mvnos(message.get("payload",{}).get("limit", 10))
+    await websocket.send(json.dumps({"command": "query_database", "status": "success", "data": {"message": "query_database not fully implemented yet"}}))
+
+
+# --- WebSocket Request Handler ---
+async def mcp_handler(websocket, path):
+    logger.info(f"Client connected: {websocket.remote_address}")
+    try:
+        async for message_str in websocket:
+            logger.debug(f"Received message: {message_str}")
+            try:
+                message = json.loads(message_str)
+                command = message.get("command")
+
+                if command == "get_config":
+                    await get_config_handler(websocket, message)
+                elif command == "run_crawl":
+                    await run_crawl_handler(websocket, message)
+                elif command == "parse_data":
+                    await parse_data_handler(websocket, message)
+                elif command == "get_report":
+                    await get_report_handler(websocket, message)
+                elif command == "query_database":
+                    await query_database_handler(websocket, message)
+                # Example of a non-authenticated command (e.g. ping)
+                elif command == "ping":
+                    await websocket.send(json.dumps({"command": "pong", "original_message": message.get("payload")}))
+                else:
+                    logger.warning(f"Unknown command: {command}")
+                    await websocket.send(json.dumps({"error": "Unknown command", "success": False, "command_received": command}))
+
+            except json.JSONDecodeError:
+                logger.error("Invalid JSON received")
+                await websocket.send(json.dumps({"error": "Invalid JSON format", "success": False}))
+            except Exception as e:
+                logger.error(f"Error processing message: {e}", exc_info=True)
+                await websocket.send(json.dumps({"error": str(e), "success": False}))
+    except websockets.exceptions.ConnectionClosedError:
+        logger.info(f"Client disconnected: {websocket.remote_address} (ConnectionClosedError)")
+    except websockets.exceptions.ConnectionClosedOK:
+        logger.info(f"Client disconnected: {websocket.remote_address} (ConnectionClosedOK)")
+    except Exception as e:
+        logger.error(f"Connection error: {e}", exc_info=True)
+    finally:
+        logger.info(f"Connection closed for {websocket.remote_address}")
+
+
+# --- Main Server Function ---
+async def main():
+    # Ensure logs directory exists
+    import os
+    if not os.path.exists("logs"):
+        os.makedirs("logs")
+
+    server = await websockets.serve(mcp_handler, "0.0.0.0", 8765)
+    logger.info("GHOST MCP Server started on ws://0.0.0.0:8765")
+    await server.wait_closed()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- Add ghost_mcp_server.py with WebSocket, auth, logging, and placeholder functions for core GHOST modules.
- Update docker-compose.yml to include the ghost-mcp service.
- Create MCP_QUICKSTART.md with connection info and example commands.