### PR TITLE
Create MCPv2 server and deployment package for remote execution

### DIFF
--- a/MCP_VERIFICATION_CHECKLIST.md
+++ b/MCP_VERIFICATION_CHECKLIST.md
@@ -1,0 +1,125 @@
+# MCP Server v2 Verification Checklist
+
+## For the Operator Deploying the Server
+
+This checklist helps ensure the GHOST DMPM MCP Server (v2 with Health Check) is deployed and functioning correctly.
+
+### I. Pre-Deployment Checks
+- [ ] **Python Version**: Python 3.9+ is installed and accessible (`python3 --version`).
+- [ ] **Port Availability**: Port 8765 (or the configured port for MCP) is available and not in use by another application.
+    *   *To check (Linux/macOS)*: `sudo lsof -i :8765`
+    *   *To check (Windows)*: `netstat -ano | findstr :8765`
+- [ ] **Files Present**: All necessary files from the `ghost-dmpm-mcp-bundle` are present in the deployment directory:
+    - [ ] `ghost_mcp_server.py` (this is the renamed `ghost_mcp_server_v2.py`)
+    - [ ] `ghost_config.py`
+    - [ ] `ghost_db.py`
+    - [ ] `mcp_client.py`
+    - [ ] `requirements.txt`
+    - [ ] `test_mcp_complete.py`
+    - [ ] `DEPLOY_INSTRUCTIONS.md`
+    - [ ] `config/` directory (if default config is used, or with `ghost_config.json` if customized)
+    - [ ] `data/` directory (will be created by server if not present, for the database)
+    - [ ] `logs/` directory (will be created by server if not present)
+- [ ] **Dependencies**: Python package dependencies are ready to be installed from `requirements.txt`.
+    *   Consider using a Python virtual environment.
+
+### II. Deployment & Initial Startup
+1. [ ] **Navigate to Bundle Directory**: `cd ghost-dmpm-mcp-bundle`
+2. [ ] **(Recommended) Activate Virtual Environment**:
+    *   `python3 -m venv .venv`
+    *   `source .venv/bin/activate` (Linux/macOS) or `.venv\Scripts\activate` (Windows)
+3. [ ] **Install Dependencies**: `pip3 install -r requirements.txt`
+    *   Verify successful installation without errors.
+4. [ ] **Start MCP Server**: `python3 ghost_mcp_server.py`
+    *   Observe console output for startup messages.
+5. [ ] **Confirm Startup Messages**: Check console for logs similar to:
+    ```
+    Initializing GHOST MCP Server v2...
+    Attempting to run server on <host>:<port>...
+    INFO:MCP-Server:Starting GHOST MCP Server v2 on ws://<host>:<port>
+    INFO:MCP-Server:Health check available at ws://<host>:<port>/health (GET request or WebSocket connection)
+    INFO:MCP-Server:Server startup complete. Waiting for connections.
+    ```
+    *   Note any error messages during startup.
+
+### III. Health Check Verification
+1. [ ] **Access Health Endpoint**: Use the Python script from `DEPLOY_INSTRUCTIONS.md` or `test_mcp_complete.py`'s health check function.
+    ```bash
+    python3 -c "
+    import asyncio
+    import websockets
+    import json
+
+    async def check_health():
+        uri = 'ws://localhost:8765/health' # Adjust host/port if not default
+        try:
+            async with websockets.connect(uri) as websocket:
+                response = await websocket.recv()
+                print('Health Check Response:')
+                data = json.loads(response)
+                print(json.dumps(data, indent=2))
+                if data.get('status') in ['healthy', 'degraded']:
+                    print('\n✅ Health status field is valid.')
+                else:
+                    print('\n❌ Health status field is MISSING or INVALID.')
+        except Exception as e:
+            print(f'Error during health check: {e}')
+
+    asyncio.run(check_health())
+    "
+    ```
+2. [ ] **Verify Health JSON Response**: The output should be a JSON object similar to:
+    ```json
+    {
+      "status": "healthy",  // or "degraded" if DB has issues
+      "timestamp": "YYYY-MM-DDTHH:MM:SS.ffffff",
+      "version": "2.0.0",
+      "uptime": "Xd Yh Zm", // Example: "0d 0h 5m"
+      "components": {
+        "database": "healthy", // or "degraded"
+        "websocket": "healthy"
+      },
+      "metrics": {
+        "connected_clients": 0, // Initially 0
+        "tracked_mvnos": 0  // Or actual count if DB is populated
+      }
+    }
+    ```
+    *   Check for `"status": "healthy"` (or `"degraded"` if database is not yet fully populated/accessible but server is up).
+    *   Confirm `version` is `"2.0.0"`.
+    *   Ensure `components.database` and `components.websocket` statuses are present.
+
+### IV. Basic Client Connectivity Test
+1. [ ] **Run MCP Client Test**: Execute `python3 mcp_client.py` (ensure it's configured with the correct auth token if not using the default).
+2. [ ] **Observe Client Output**: Look for successful connection, authentication, and query results. Example snippet:
+    ```
+    [✓] Connected to GHOST MCP Server
+    [✓] Authenticated successfully.
+    [✓] get_top_mvnos (Sample): ...
+    [✓] get_system_status (Sample): ...
+    [✓] get_recent_alerts (Sample): ...
+    Connection closed.
+    ```
+    *   Note any errors like "Authentication failed" or "Connection refused".
+
+### V. Comprehensive Test Suite (Optional but Recommended)
+1. [ ] **Run Full Test Suite**: `python3 test_mcp_complete.py`
+2. [ ] **Review Test Results**: Check the summary for passed/failed tests. Address any failures.
+
+### VI. Final Operational Checks
+- [ ] **Server Stability**: Server remains running without crashing after tests.
+- [ ] **Log Review**: Briefly check `logs/ghost_YYYYMMDD.log` and `logs/ghost_mcp_server.log` (if configured differently by GhostConfig) for any unexpected errors or excessive warnings.
+
+### Success Indicators
+- ✅ Health endpoint returns valid JSON with an acceptable status (`healthy` or `degraded`).
+- ✅ MCP server starts without critical errors logged to console.
+- ✅ `mcp_client.py` can connect, authenticate, and retrieve data.
+- ✅ `test_mcp_complete.py` shows a high number of passed tests.
+- ✅ Server remains operational after tests.
+
+### Common Troubleshooting Points (Refer to `DEPLOY_INSTRUCTIONS.md` for more details)
+*   **Port Conflicts**: Ensure port 8765 (or configured port) is free.
+*   **Python Import Errors**: Check virtual environment, `requirements.txt` installation, and file locations.
+*   **Database Issues**: Verify `config/ghost_config.json` points to a writable database location. If the GHOST DMPM system requires it, run `main.py` (or equivalent data population script) to populate the database.
+*   **Firewall**: Ensure the server port is not blocked by local or network firewalls.
+*   **Authentication Token**: Ensure `mcp_client.py` and any other clients are using the correct `mcp_server.auth_token` defined in `config/ghost_config.json`.

--- a/REMOTE_DEPLOYMENT.md
+++ b/REMOTE_DEPLOYMENT.md
@@ -1,0 +1,128 @@
+# GHOST DMPM MCP Server - Remote Deployment Guide
+
+This guide is for an operator who will deploy the MCP server on a remote system where Python 3.9+ is available.
+
+## Items You Should Receive
+
+1.  **Deployment Bundle**: `ghost-dmpm-mcp-bundle.tar.gz`
+2.  **(This File)** `REMOTE_DEPLOYMENT.md`
+
+## Deployment Steps for Remote Operator
+
+1.  **Transfer and Extract Bundle**:
+    *   Copy `ghost-dmpm-mcp-bundle.tar.gz` to the remote server.
+    *   Log in to the remote server.
+    *   Extract the bundle:
+        ```bash
+        tar -xzf ghost-dmpm-mcp-bundle.tar.gz
+        cd ghost-dmpm-mcp-bundle
+        ```
+        (This will create a directory named `ghost-dmpm-mcp-bundle` and you should `cd` into it.)
+
+2.  **Set Up Python Environment (Recommended: Virtual Environment)**:
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    ```
+    *Note: If `python3` is not found, try `python`. Ensure it's Python 3.9+.*
+
+3.  **Install Dependencies**:
+    *   The bundle includes `requirements.txt`. Install these:
+        ```bash
+        pip3 install -r requirements.txt
+        ```
+    *   If `pip3` is not found, try `pip`.
+    *   A key dependency is `websockets`. If `requirements.txt` is minimal or missing, at least install websockets: `pip3 install websockets`.
+
+4.  **Review Configuration (Optional but Recommended)**:
+    *   The main server configuration is in `config/ghost_config.json`.
+    *   Key settings to check:
+        *   `mcp_server.host`: Should typically be `0.0.0.0` to listen on all interfaces.
+        *   `mcp_server.port`: Default is `8765`. Ensure this port is open on the server's firewall.
+        *   `database.path`: Default is `data/ghost_data.db`. Ensure the `data` directory is writable by the user running the server.
+        *   `mcp_server.auth_token`: Note this token if clients need to connect.
+
+5.  **Start the MCP Server**:
+    *   Run the server in the background using `nohup` and redirect output for logging:
+        ```bash
+        nohup python3 ghost_mcp_server.py > mcp_server.log 2>&1 &
+        ```
+    *   This will start the server, and it will continue running even if you log out. Output (and errors) will go to `mcp_server.log` in the current directory (`ghost-dmpm-mcp-bundle`).
+
+6.  **Verify Server is Running**:
+    *   Wait a few seconds for the server to initialize.
+    *   Check the log file for startup messages:
+        ```bash
+        tail -n 20 mcp_server.log
+        ```
+        Look for lines like:
+        `INFO:MCP-Server:Starting GHOST MCP Server v2 on ws://0.0.0.0:8765`
+        `INFO:MCP-Server:Server startup complete. Waiting for connections.`
+    *   Check if the process is running:
+        ```bash
+        ps aux | grep ghost_mcp_server.py
+        ```
+    *   Test the health endpoint (from the server itself, if `curl` is available):
+        ```bash
+        # This curl command may not work directly as it's a WebSocket endpoint.
+        # curl http://localhost:8765/health
+        # A more reliable test is using the Python snippet below.
+
+        # Use this Python command to test the WebSocket health endpoint:
+        python3 -c "import asyncio, websockets, json; \
+        async def c(): \
+            u='ws://localhost:8765/health'; \
+            try: \
+                async with websockets.connect(u) as ws: r = await ws.recv(); print(json.dumps(json.loads(r), indent=2)); \
+            except Exception as e: print(f'Failed: {e}'); \
+        asyncio.run(c())"
+        ```
+        This should print a JSON response with `"status": "healthy"` or `"status": "degraded"`.
+
+7.  **Report Back**:
+    *   Provide the output of the `tail mcp_server.log` command.
+    *   Provide the output of the Python health check command.
+    *   Confirm if the server process is running.
+    *   Report any errors encountered.
+
+## What Success Looks Like (for the Remote Operator to report)
+
+*   **Console/Log Output**: The `mcp_server.log` should show successful startup messages without critical errors.
+*   **Health Check**: The Python health check script should return JSON with `status: "healthy"` (or `degraded` if the database is not yet fully initialized, which might be okay for a first run).
+*   **Process Running**: `ps aux | grep ghost_mcp_server.py` shows the server process.
+
+## For the Requestor: Accessing the Remotely Deployed Server
+
+Once the remote operator confirms the server is running, you might need to access it.
+
+### 1. Direct Access (If server's IP/port is publicly accessible and firewalled correctly)
+*   Use `mcp_client.py` configured with the remote server's IP address and port.
+
+### 2. SSH Tunnel (Secure way to access a port on a remote server as if it were local)
+*   From your local machine:
+    ```bash
+    ssh -L 8765:<remote_server_ip_or_localhost>:8765 user@remote-server-ip
+    ```
+    *   Replace `8765` with the local port you want to use (e.g., `9000:localhost:8765` to map remote 8765 to local 9000).
+    *   `<remote_server_ip_or_localhost>`: Use `localhost` if the MCP server on the remote machine is bound to `0.0.0.0` or `127.0.0.1`. If it's bound to a specific IP on the remote, use that.
+    *   `user@remote-server-ip`: Your SSH login credentials for the remote server.
+*   After establishing the tunnel, you can point `mcp_client.py` (or other tools) to `ws://localhost:8765` (or your chosen local port) on your machine.
+
+### 3. Reverse Proxy (e.g., nginx, if a web server is available on the remote machine)
+*   This is more complex and involves configuring the web server on the remote machine to pass requests to the MCP server. Example nginx config snippet:
+    ```nginx
+    # In your nginx server block for the desired domain/IP
+
+    location /mcp_websocket/ {  # Example path for the MCP server
+        proxy_pass http://localhost:8765; # Assuming MCP runs on localhost:8765 on the remote server
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 86400s; # Keep connection open longer for WebSockets
+    }
+    ```
+*   Clients would then connect to `ws://your-remote-domain.com/mcp_websocket/`.
+
+Choose the access method appropriate for your security requirements and network setup.
+The SSH tunnel is often a good balance of security and simplicity for direct testing.

--- a/create_deployment_bundle.sh
+++ b/create_deployment_bundle.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+# Creates a deployment bundle for someone who can run Python
+
+echo "Creating GHOST DMPM MCP Deployment Bundle..."
+
+# Create bundle directory
+BUNDLE_DIR="ghost-dmpm-mcp-bundle"
+mkdir -p $BUNDLE_DIR
+
+# Copy all necessary files
+# Ensure we copy the NEW ghost_mcp_server_v2.py and rename it to ghost_mcp_server.py in the bundle
+if [ -f "ghost_mcp_server_v2.py" ]; then
+    cp ghost_mcp_server_v2.py $BUNDLE_DIR/ghost_mcp_server.py
+else
+    echo "ERROR: ghost_mcp_server_v2.py not found!"
+    # Attempt to copy original if v2 is missing, though this is not ideal
+    cp ghost_mcp_server.py $BUNDLE_DIR/
+fi
+
+# Copy other ghost files, mcp_client, requirements, etc.
+# Using a find command to be more robust for other ghost_*.py files
+find . -maxdepth 1 -name 'ghost_*.py' ! -name 'ghost_mcp_server_v2.py' -exec cp {} $BUNDLE_DIR/ \;
+# Explicitly copy other critical files
+cp mcp_client.py $BUNDLE_DIR/
+cp requirements.txt $BUNDLE_DIR/
+
+# Optional files, check if they exist
+if [ -f "docker-compose.yml" ]; then
+    cp docker-compose.yml $BUNDLE_DIR/
+fi
+if [ -f "MCP_QUICKSTART.md" ]; then
+    cp MCP_QUICKSTART.md $BUNDLE_DIR/
+fi
+if [ -d "config" ]; then
+    mkdir -p $BUNDLE_DIR/config
+    cp config/* $BUNDLE_DIR/config/
+fi
+if [ -d "data" ]; then
+    mkdir -p $BUNDLE_DIR/data
+    # cp data/* $BUNDLE_DIR/data/ # Avoid copying actual data for a clean bundle
+    echo "Note: 'data' directory structure created, but existing data not bundled." > $BUNDLE_DIR/data/placeholder.txt
+fi
+if [ -d "logs" ]; then
+    mkdir -p $BUNDLE_DIR/logs
+    echo "Note: 'logs' directory created for server operation." > $BUNDLE_DIR/logs/placeholder.txt
+fi
+
+
+# Create deployment instructions
+cat > $BUNDLE_DIR/DEPLOY_INSTRUCTIONS.md << 'INSTRUCTIONS'
+# GHOST DMPM MCP Deployment Instructions
+
+## Requirements
+- Python 3.9+ (ensure pip is available)
+- Docker and docker-compose (optional, if using Docker deployment)
+- Network access on port 8765 (or as configured)
+
+## Setup & Deployment
+
+### 1. Prepare Environment
+Ensure Python 3.9+ is installed. It's recommended to use a virtual environment:
+```bash
+python3 -m venv .venv
+source .venv/bin/activate  # On Linux/macOS
+# .venv\Scripts\activate   # On Windows
+```
+
+### 2. Install Dependencies
+```bash
+pip3 install -r requirements.txt
+```
+*Note: `requirements.txt` should include `websockets` and any other dependencies for `ghost_config.py`, `ghost_db.py`, etc.*
+
+### 3. Configuration (Optional)
+- The server uses `config/ghost_config.json`. A default is usually created.
+- Key settings:
+    - `database.path`: Location of the SQLite database (e.g., "data/ghost_data.db")
+    - `mcp_server.auth_token`: Authentication token for clients.
+    - `mcp_server.host`, `mcp_server.port`: Server listen address and port.
+
+### 4. Running the Server
+
+#### Option A: Direct Python Execution
+```bash
+python3 ghost_mcp_server.py
+```
+The server will log to the console and to `logs/ghost_YYYYMMDD.log`.
+
+#### Option B: Docker (If `docker-compose.yml` is configured)
+```bash
+docker-compose up --build -d
+```
+To view logs: `docker-compose logs -f mcp_server` (assuming service name is `mcp_server`)
+
+## Verification
+
+### 1. Check Server Logs
+Look for messages like:
+```
+INFO:MCP-Server:Starting GHOST MCP Server v2 on ws://0.0.0.0:8765
+INFO:MCP-Server:Health check available at ws://0.0.0.0:8765/health (GET request or WebSocket connection)
+INFO:MCP-Server:Server startup complete. Waiting for connections.
+```
+
+### 2. Test Health Endpoint
+From a terminal on the same machine (or another machine that can reach the server):
+```bash
+# Using curl (if server is on localhost:8765 and accessible via HTTP for health, though it's a WebSocket server)
+# This might not work directly if the health check is WebSocket only.
+# curl http://localhost:8765/health
+
+# Using Python to test WebSocket health endpoint:
+python3 -c "
+import asyncio
+import websockets
+import json
+
+async def check_health():
+    uri = 'ws://localhost:8765/health' # Adjust if host/port differs
+    try:
+        async with websockets.connect(uri) as websocket:
+            response = await websocket.recv()
+            print('Health Check Response:')
+            print(json.dumps(json.loads(response), indent=2))
+    except Exception as e:
+        print(f'Error during health check: {e}')
+
+asyncio.run(check_health())
+"
+```
+Expected output is a JSON object with `"status": "healthy"` (or `"degraded"` if DB issues).
+
+### 3. Test with MCP Client
+Run the provided `mcp_client.py`:
+```bash
+python3 mcp_client.py
+```
+This should connect, authenticate, and perform some basic queries.
+
+## Test Suite
+A more comprehensive test suite is available:
+```bash
+python3 test_mcp_complete.py
+```
+
+## Troubleshooting
+1.  **Port already in use (e.g., 8765)**:
+    *   Find process: `sudo lsof -i :8765` (Linux/macOS) or `netstat -ano | findstr :8765` (Windows)
+    *   Kill the process or change the port in `config/ghost_config.json`.
+2.  **Import Errors (`ModuleNotFoundError`)**:
+    *   Ensure you are in the correct directory (`ghost-dmpm-mcp-bundle`).
+    *   Make sure all `ghost_*.py` files are present in this directory.
+    *   Verify dependencies are installed: `pip3 install -r requirements.txt`.
+    *   If using a virtual environment, ensure it's activated.
+3.  **Connection Refused/Timeout (Client or Health Check)**:
+    *   Verify the server is running and listening on the correct host/port.
+    *   Check firewalls (local and network) are not blocking the port.
+    *   If running in Docker, ensure ports are correctly mapped.
+4.  **Database Issues (`OperationalError`, etc.)**:
+    *   Ensure the path in `config/ghost_config.json` for `database.path` is correct and writable.
+    *   If it's a new setup, the database should be created automatically.
+    *   The `main.py` script (if included and part of the broader GHOST DMPM system) might be needed to populate initial data. The MCP server itself doesn't populate the DB.
+INSTRUCTIONS
+
+# Create test suite (as provided by user)
+cat > $BUNDLE_DIR/test_mcp_complete.py << 'TEST'
+#!/usr/bin/env python3
+"""Complete MCP test suite"""
+import asyncio
+import json
+import websockets # Explicitly import for health check part
+from mcp_client import GhostMCPClient # Assumes mcp_client.py is in the same dir
+
+async def run_tests():
+    print("=== GHOST DMPM Complete Test Suite ===\n")
+
+    # Default client for most tests (uses token from mcp_client.py's default)
+    client = GhostMCPClient()
+    passed_count = 0
+    failed_count = 0
+
+    # Define tests as (Name, function_to_call, requires_connection_first)
+    # test_auth needs special handling as it tests failed auth too
+
+    print("--- Standard Client Tests ---")
+
+    async def run_single_test(test_name, test_func, use_client):
+        nonlocal passed_count, failed_count
+        print(f"Testing {test_name}...", end=" ", flush=True)
+        try:
+            await test_func(use_client)
+            print("✅ PASSED")
+            passed_count += 1
+        except Exception as e:
+            print(f"❌ FAILED: {e}")
+            # import traceback
+            # traceback.print_exc() # Uncomment for detailed traceback during debugging
+            failed_count += 1
+
+    # Connection Test (special, as others depend on it)
+    print("Testing Connection...", end=" ", flush=True)
+    try:
+        await client.connect()
+        print("✅ PASSED (Connected)")
+        passed_count += 1
+        connection_ok = True
+    except Exception as e:
+        print(f"❌ FAILED to connect: {e}")
+        failed_count += 1
+        connection_ok = False
+    finally:
+        if client.websocket: # Ensure client is closed if connect was attempted
+             await client.close()
+             print("Closed client connection post-connection test.")
+
+    if connection_ok:
+        # These tests require a client that can successfully connect and auth
+        standard_tests = [
+            ("Get Top MVNOs (requires auth)", test_get_top_mvnos),
+            ("Search MVNO (requires auth)", test_search_mvno),
+            ("Recent Alerts (requires auth)", test_recent_alerts),
+            ("System Status (requires auth)", test_system_status),
+        ]
+        for name, func in standard_tests:
+            # Each of these tests will establish its own connection using the default client
+            await run_single_test(name, func, client)
+    else:
+        print("Skipping standard authenticated tests due to initial connection failure.")
+
+    # Standalone tests (manage their own client or don't need standard auth)
+    print("\n--- Standalone Tests ---")
+    await run_single_test("Authentication Logic", test_auth_logic, None) # test_auth_logic uses its own client
+    await run_single_test("Health Check Endpoint", test_health_check_endpoint, None) # test_health_check uses websockets directly
+
+    print(f"\n=== Results: {passed_count} passed, {failed_count} failed ===")
+
+# Test function implementations
+async def test_auth_logic(_): # Param is placeholder, not used
+    # Test with wrong token
+    bad_client = GhostMCPClient(token="wrong-token-for-sure")
+    try:
+        await bad_client.connect() # This connect includes authentication attempt
+        # If it reaches here, auth with wrong token somehow passed, or client doesn't raise on auth fail
+        if bad_client.websocket and bad_client.websocket.open: # Check if actually connected despite bad token
+             await bad_client.close()
+        raise Exception("Authentication with wrong token should have failed or resulted in no usable connection.")
+    except websockets.exceptions.InvalidStatusCode as isc:
+        # This might be an expected way for server to reject bad auth if it closes connection
+        print(f"(Expected auth failure with status code: {isc.status_code})", end=" ")
+    except Exception as e:
+        # General exception could be fine if it indicates auth failure (e.g. custom client exception)
+        print(f"(Expected auth failure: {type(e).__name__})", end=" ")
+        pass # Expected path for failed auth
+
+    # Test with correct token (implicitly done by other tests, but can be explicit if needed)
+    # good_client = GhostMCPClient() # Assumes default token in mcp_client.py is correct
+    # await good_client.connect()
+    # assert good_client.websocket and good_client.websocket.open, "Client with good token failed to connect/authenticate"
+    # await good_client.close()
+
+
+async def test_get_top_mvnos(client):
+    await client.connect() # Connects and authenticates
+    result = await client.get_top_mvnos(3) # Test with n=3
+    assert "result" in result, "Result key missing"
+    assert "mvnos" in result["result"], "MVNOs key missing in result"
+    assert len(result["result"]["mvnos"]) <= 3, "More MVNOs returned than requested"
+    await client.close()
+
+async def test_search_mvno(client):
+    await client.connect()
+    # Assuming "Mint Mobile" is a known MVNO for testing; adjust if needed
+    result = await client.search_mvno("Mint Mobile")
+    assert "result" in result, "Result key missing"
+    # Search can return an error if not found, which is valid.
+    # This assertion might need to be more nuanced based on expected test data.
+    # For now, just check that the 'result' field exists.
+    # If it must be found: assert "mvno" in result["result"] or "error" not in result["result"]
+    await client.close()
+
+async def test_recent_alerts(client):
+    await client.connect()
+    result = await client.get_alerts(7) # Assuming get_alerts is a method in GhostMCPClient
+    assert "result" in result, "Result key missing"
+    assert "alerts" in result["result"], "Alerts key missing in result"
+    await client.close()
+
+async def test_system_status(client):
+    await client.connect()
+    result = await client.query("get_system_status", {}) # Generic query
+    assert "result" in result, "Result key missing"
+    assert "server_uptime" in result["result"], "System status missing uptime"
+    await client.close()
+
+async def test_health_check_endpoint(_): # Param is placeholder
+    uri = 'ws://localhost:8765/health' # Adjust if host/port differs
+    async with websockets.connect(uri) as websocket:
+        response_str = await websocket.recv()
+        data = json.loads(response_str)
+        assert data.get("status") in ["healthy", "degraded"], f"Unexpected status in health check: {data.get('status')}"
+        assert "timestamp" in data, "Health check missing timestamp"
+        assert "components" in data, "Health check missing components"
+
+if __name__ == "__main__":
+    asyncio.run(run_tests())
+TEST
+
+# Create tar.gz bundle
+# Using GNU tar options for compatibility.
+tar -czf ghost-dmpm-mcp-bundle.tar.gz "$BUNDLE_DIR/"
+
+echo "✅ Deployment bundle created: ghost-dmpm-mcp-bundle.tar.gz"
+echo ""
+echo "To deploy, transfer this file to a system with Python and run:"
+echo "  tar -xzf ghost-dmpm-mcp-bundle.tar.gz"
+echo "  cd $BUNDLE_DIR"
+echo "  cat DEPLOY_INSTRUCTIONS.md"
+echo "  # Then follow instructions, e.g., pip install and run server."
+EOF
+
+# Make the bundle script executable
+chmod +x create_deployment_bundle.sh

--- a/ghost-mcp.service
+++ b/ghost-mcp.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=GHOST DMPM MCP Server
+After=network.target
+
+[Service]
+Type=simple
+User=ghost
+WorkingDirectory=/opt/ghost-dmpm
+ExecStart=/usr/bin/python3 /opt/ghost-dmpm/ghost_mcp_server.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ghost_mcp_server_v2.py
+++ b/ghost_mcp_server_v2.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""GHOST Protocol MCP Server v2 - With Health Check"""
+import asyncio
+import websockets
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+import sys
+
+# Add parent directory to path for imports
+# Use an absolute path resolution to be more robust
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from ghost_config import GhostConfig
+from ghost_db import GhostDatabase
+
+class GhostMCPServer:
+    def __init__(self, config):
+        self.config = config
+        self.db = GhostDatabase(config)
+        self.logger = config.get_logger("MCP-Server") # Uses GhostConfig's logger
+        self.authenticated_clients = set()
+        self.start_time = datetime.now()
+
+    def get_uptime(self):
+        """Calculate server uptime"""
+        delta = datetime.now() - self.start_time
+        return f"{delta.days}d {delta.seconds//3600}h {(delta.seconds//60)%60}m"
+
+    async def health_check_handler(self, websocket, path):
+        """Handle health check requests on /health path"""
+        if path == "/health":
+            self.logger.info(f"Health check requested from {websocket.remote_address}")
+            try:
+                # Test database connection
+                db_status_text = "healthy"
+                db_mvnos_count = 0
+                try:
+                    # Ensure get_database_stats is robust or wrapped
+                    stats = self.db.get_database_stats()
+                    # The user's V2 template uses 'mvno_count', original uses 'total_mvnos'
+                    # Let's try to be compatible or use a known key from original GhostDB if different
+                    db_mvnos_count = stats.get("total_mvnos", stats.get("mvno_count", 0))
+                except Exception as db_exc:
+                    self.logger.error(f"Health check: Database stat query failed: {db_exc}")
+                    db_status_text = "degraded"
+
+                health_status = {
+                    "status": "healthy", # Overall status, can be changed if critical components fail
+                    "timestamp": datetime.now().isoformat(),
+                    "version": "2.0.0", # Updated version
+                    "uptime": self.get_uptime(),
+                    "components": {
+                        "database": db_status_text,
+                        "websocket": "healthy"
+                    },
+                    "metrics": {
+                        "connected_clients": len(self.authenticated_clients),
+                        "tracked_mvnos": db_mvnos_count
+                    }
+                }
+
+                await websocket.send(json.dumps(health_status))
+
+            except Exception as e:
+                self.logger.error(f"Error during health check: {e}", exc_info=True)
+                error_status = {
+                    "status": "error",
+                    "error_message": str(e), # changed from "error" to avoid conflict with outer key
+                    "timestamp": datetime.now().isoformat()
+                }
+                try:
+                    await websocket.send(json.dumps(error_status))
+                except Exception as send_err:
+                    self.logger.error(f"Failed to send error status during health check: {send_err}")
+            finally:
+                # Ensure connection is closed for health checks
+                try:
+                    await websocket.close()
+                except Exception:
+                    pass # Ignore errors on close, it might already be closed
+            return True # Indicates /health path was handled
+
+        return False # Path was not /health
+
+    async def authenticate(self, websocket, token):
+        """Authenticate WebSocket connection"""
+        # Using "mcp_server.auth_token" as per original, not "mcp.auth_token"
+        expected_token = self.config.get("mcp_server.auth_token", "ghost-mcp-2024")
+
+        if token == expected_token:
+            self.authenticated_clients.add(websocket)
+            self.logger.info(f"Client authenticated: {websocket.remote_address}")
+            return True
+        else:
+            self.logger.warning(f"Authentication failed for client {websocket.remote_address} (token: {token[:10]}...)")
+            return False
+
+    async def handle_message(self, websocket, message_str):
+        """Route messages to appropriate handlers based on JSON-RPC like structure"""
+        request_id = None # For JSON-RPC
+        try:
+            data = json.loads(message_str)
+            method = data.get('method')
+            params = data.get('params', {})
+            request_id = data.get('id')
+
+            self.logger.info(f"Received method: {method} from {websocket.remote_address} (ID: {request_id})")
+
+            # Handle authentication separately as it's a prerequisite for others
+            if method == 'authenticate':
+                token = params.get('token')
+                is_authenticated = await self.authenticate(websocket, token)
+                result_payload = {"authenticated": is_authenticated}
+                if not is_authenticated:
+                    result_payload["error"] = "Authentication failed"
+                return self._format_response(result_payload, request_id)
+
+            # Check authentication for all other methods
+            if websocket not in self.authenticated_clients:
+                self.logger.warning(f"Unauthenticated request for '{method}' from {websocket.remote_address}")
+                return self._format_response(None, request_id, error="Client not authenticated. Please authenticate first.")
+
+            # Route to method handlers
+            if method == 'get_top_mvnos':
+                result_data = await self.get_top_mvnos(params.get('n', 10))
+            elif method == 'search_mvno':
+                result_data = await self.search_mvno(params.get('mvno_name'))
+            elif method == 'get_recent_alerts':
+                result_data = await self.get_recent_alerts(params.get('days', 7))
+            elif method == 'get_mvno_trend':
+                result_data = await self.get_mvno_trend(
+                    params.get('mvno_name'),
+                    params.get('days', 30)
+                )
+            elif method == 'get_system_status':
+                result_data = await self.get_system_status()
+            else:
+                self.logger.warning(f"Unknown method '{method}' requested by {websocket.remote_address}")
+                return self._format_response(None, request_id, error=f"Unknown method: {method}")
+
+            return self._format_response(result_data, request_id)
+
+        except json.JSONDecodeError:
+            self.logger.error(f"Invalid JSON received from {websocket.remote_address}: {message_str[:100]}")
+            return self._format_response(None, request_id, error="Invalid JSON format")
+        except Exception as e:
+            self.logger.error(f"Error handling message for method {data.get('method', 'unknown')} from {websocket.remote_address}: {e}", exc_info=True)
+            return self._format_response(None, request_id, error=str(e))
+
+    def _format_response(self, result=None, request_id=None, error=None):
+        """Helper to format JSON-RPC like responses"""
+        response = {"timestamp": datetime.now().isoformat()}
+        if request_id is not None:
+            response["id"] = request_id
+
+        if error:
+            response["error"] = error
+        else:
+            response["result"] = result
+        return response
+
+    async def serve(self, websocket, path):
+        """Handle WebSocket connections"""
+        # Health check is a special case, doesn't follow JSON-RPC message structure
+        if await self.health_check_handler(websocket, path):
+            # health_check_handler closes the websocket itself
+            return
+
+        self.logger.info(f"New connection from {websocket.remote_address} on path '{path}'")
+
+        try:
+            # Initial auth message is expected from client upon connection if not /health
+            # This example structure assumes client sends auth first for other paths.
+            # Alternatively, client can connect then send auth message.
+            # For simplicity, we'll let handle_message manage auth flow.
+
+            async for message_str in websocket:
+                response_payload = await self.handle_message(websocket, message_str)
+                await websocket.send(json.dumps(response_payload))
+
+        except websockets.exceptions.ConnectionClosed:
+            self.logger.info(f"Connection closed: {websocket.remote_address}")
+        except websockets.exceptions.ConnectionClosedError:
+            self.logger.info(f"Connection closed with error: {websocket.remote_address}")
+        except websockets.exceptions.ConnectionClosedOK:
+            self.logger.info(f"Connection closed gracefully: {websocket.remote_address}")
+        except Exception as e:
+            self.logger.error(f"Unexpected error in serve loop for {websocket.remote_address}: {e}", exc_info=True)
+        finally:
+            self.authenticated_clients.discard(websocket)
+            self.logger.info(f"Cleaned up connection for {websocket.remote_address}. Current clients: {len(self.authenticated_clients)}")
+
+    # --- Methods from original ghost_mcp_server.py ---
+    def _assess_leniency(self, score):
+        """Convert score to human-readable assessment"""
+        if score is None:
+            return "UNKNOWN"
+        if score >= 4.0:
+            return "HIGHLY LENIENT - Minimal verification"
+        elif score >= 3.0:
+            return "LENIENT - Basic verification only"
+        elif score >= 2.0:
+            return "MODERATE - Standard verification"
+        else:
+            return "STRINGENT - Enhanced verification"
+
+    async def get_top_mvnos(self, n=10):
+        """Get top N lenient MVNOs from database"""
+        self.logger.info(f"Executing get_top_mvnos with n={n}")
+        mvnos_data = self.db.get_top_mvnos(n)
+
+        return {
+            "mvnos": [
+                {
+                    "rank": i + 1,
+                    "name": mvno['mvno_name'],
+                    "score": mvno['leniency_score'],
+                    "assessment": self._assess_leniency(mvno['leniency_score']),
+                    "last_updated": mvno['crawl_timestamp']
+                }
+                for i, mvno in enumerate(mvnos_data)
+            ],
+            "total_count": len(mvnos_data)
+            # "generated_at" removed, now part of _format_response wrapper
+        }
+
+    async def search_mvno(self, mvno_name):
+        """Search for a specific MVNO by name"""
+        self.logger.info(f"Executing search_mvno for {mvno_name}")
+        if not mvno_name:
+            return {"error": "MVNO name not provided."} # This will be wrapped by _format_response
+
+        mvno_data = self.db.get_mvno_by_name(mvno_name)
+        if mvno_data:
+            return {
+                "mvno": {
+                    "name": mvno_data['mvno_name'],
+                    "score": mvno_data['leniency_score'],
+                    "assessment": self._assess_leniency(mvno_data['leniency_score']),
+                    "policy_snapshot": json.loads(mvno_data['policy_snapshot']) if mvno_data.get('policy_snapshot') else None,
+                    "last_updated": mvno_data['crawl_timestamp'],
+                    "source_url": mvno_data.get('source_url')
+                }
+                # "generated_at" removed
+            }
+        else:
+            # This structure is fine, handle_message will wrap it with "error" key if needed
+            return {"error": f"MVNO '{mvno_name}' not found."}
+
+    async def get_recent_alerts(self, days=7):
+        """Get recent policy changes/alerts"""
+        self.logger.info(f"Executing get_recent_alerts for last {days} days")
+        changes_data = self.db.get_recent_changes(days)
+
+        return {
+            "alerts": [
+                {
+                    "mvno_name": change['mvno_name'],
+                    "change_type": change['change_type'],
+                    "old_value": change['old_value'],
+                    "new_value": change['new_value'],
+                    "detected_timestamp": change['detected_timestamp']
+                }
+                for change in changes_data
+            ],
+            "total_count": len(changes_data)
+            # "generated_at" removed
+        }
+
+    async def get_mvno_trend(self, mvno_name, days=30):
+        """Get policy trend for a specific MVNO over a period"""
+        self.logger.info(f"Executing get_mvno_trend for {mvno_name} over {days} days")
+        if not mvno_name:
+            return {"error": "MVNO name not provided."}
+
+        history_data = self.db.get_mvno_policy_history(mvno_name, days)
+        return {
+            "mvno_name": mvno_name,
+            "trend": [
+                {
+                    "timestamp": record['crawl_timestamp'],
+                    "score": record['leniency_score'],
+                    "assessment": self._assess_leniency(record['leniency_score']),
+                }
+                for record in history_data
+            ],
+            "total_count": len(history_data)
+            # "generated_at" removed
+        }
+
+    async def get_system_status(self):
+        """Get system health and statistics"""
+        self.logger.info("Executing get_system_status")
+        db_stats = self.db.get_database_stats()
+
+        return {
+            "database_status": "connected",
+            "total_mvnos_tracked": db_stats.get("total_mvnos"), # Ensure key matches GhostDB
+            "last_policy_update": db_stats.get("last_policy_update_timestamp"),
+            "total_policy_changes_logged": db_stats.get("total_changes"),
+            "server_uptime": self.get_uptime(), # Use new get_uptime method
+            "active_connections": len(self.authenticated_clients)
+            # "generated_at" removed
+        }
+    # --- End of methods from original ghost_mcp_server.py ---
+
+    async def run_server(self, host='0.0.0.0', port=8765): # Renamed from 'run' to avoid conflict if class named 'run'
+        """Start the MCP server"""
+        self.logger.info(f"Starting GHOST MCP Server v2 on ws://{host}:{port}")
+        self.logger.info(f"Health check available at ws://{host}:{port}/health (GET request or WebSocket connection)")
+
+        # Ensure logs directory exists (GhostConfig might do this, but good to be sure)
+        log_dir = Path("logs")
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        server = await websockets.serve(self.serve, host, port)
+        self.logger.info("Server startup complete. Waiting for connections.")
+        await server.wait_closed()
+
+
+if __name__ == "__main__":
+    # Basic logging configuration for startup messages if GhostConfig hasn't set it up yet.
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    print("Initializing GHOST MCP Server v2...")
+    try:
+        config = GhostConfig() # Assumes ghost_config.py is in the same directory or PYTHONPATH
+
+        # Override spaCy check if it was causing issues - for robustness during deployment
+        if hasattr(config, 'features'):
+            config.features['nlp'] = False # Ensure NLP/spaCy is marked as unavailable to prevent hangs
+
+        server = GhostMCPServer(config)
+
+        print(f"Attempting to run server on {config.get('mcp_server.host', '0.0.0.0')}:{config.get('mcp_server.port', 8765)}")
+        asyncio.run(server.run_server(
+            host=config.get('mcp_server.host', '0.0.0.0'),
+            port=config.get('mcp_server.port', 8765)
+        ))
+    except ImportError as e:
+        print(f"ERROR: Failed to import required modules: {e}")
+        print("Please ensure ghost_config.py and ghost_db.py are in the same directory or your PYTHONPATH is set correctly.")
+        print("You might also need to install dependencies from requirements.txt (e.g., pip install websockets).")
+    except websockets.exceptions.WebSocketException as wse:
+        print(f"ERROR: WebSocket specific error during startup: {wse}")
+        print("This could be due to port conflicts or network configuration issues.")
+    except OSError as oe:
+        print(f"ERROR: Operating system error during startup (e.g. port already in use): {oe}")
+        print(f"If port {config.get('mcp_server.port', 8765)} is in use, please stop the other process or change the port in config.")
+    except KeyboardInterrupt:
+        print("\nShutting down GHOST MCP server (KeyboardInterrupt)...")
+    except Exception as e:
+        print(f"An unexpected error occurred during server startup or execution: {e}")
+        logging.getLogger(__name__).error("Fatal error in __main__", exc_info=True)
+    finally:
+        print("GHOST MCP Server has shut down.")
+
+# Ensure ghost_config.py has:
+# class GhostConfig:
+#     def get_logger(self, name):
+#         logger = logging.getLogger(name)
+#         # Basic setup if not already configured by main logging.basicConfig
+#         if not logger.handlers: # Avoid adding handlers multiple times
+#             handler = logging.StreamHandler() # Or your preferred handler
+#             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+#             handler.setFormatter(formatter)
+#             logger.addHandler(handler)
+#             logger.setLevel(self.get("logging.level", "INFO")) # Use configured level
+#         return logger
+#
+#     def get(self, key, default=None):
+#         # ... (implementation of get)
+#         # Example for mcp_server.host and mcp_server.port if not deeply nested:
+#         # return self.config.get(key, default)
+#         # If nested like "mcp_server": {"host": "0.0.0.0", "port": 8765}
+#         keys = key.split('.')
+#         value = self.config
+#         for k_part in keys:
+#             if isinstance(value, dict) and k_part in value:
+#                 value = value[k_part]
+#             else:
+#                 return default
+#         return value
+
+
+# Ensure ghost_db.py has:
+# class GhostDatabase:
+#    def get_database_stats(self):
+#        # Should return a dict like {"total_mvnos": X, "last_policy_update_timestamp": Y, "total_changes": Z}
+#        # Or {"mvno_count": X ...} as per user's V2 template for health check
+#        # Example:
+#        # return {"total_mvnos": 100, "mvno_count": 100, ...}
+#        pass
+#
+#    def get_top_mvnos(self, n): pass
+#    def get_mvno_by_name(self, name): pass
+#    def get_recent_changes(self, days): pass
+#    def get_mvno_policy_history(self, name, days): pass
+#
+# Make sure the keys used (e.g. 'mvno_name', 'leniency_score', 'crawl_timestamp') match DB schema.
+# Make sure policy_snapshot is handled (e.g. json.loads) if stored as TEXT.
+# sys.path.append needed if ghost_config/ghost_db are not in same dir as server or in PYTHONPATH.
+# The V2 template adds: sys.path.append(str(Path(__file__).parent))
+# which is good if all ghost_*.py files are in the same directory.
+# If ghost_config.py or ghost_db.py are in a *parent* directory, it should be:
+# sys.path.append(str(Path(__file__).resolve().parent.parent))
+# For now, assuming they are meant to be in the same directory as ghost_mcp_server_v2.py
+# or that PYTHONPATH is correctly set by the deployment environment.
+# Changed the sys.path.append to use resolve().parent for robustness.
+# Added some more robust error handling and comments in __main__.
+# Added placeholder comments for GhostConfig and GhostDatabase for clarity.
+# Changed server.run() to server.run_server() to avoid potential name collision.
+# Made health check db stats query more robust.
+# Ensured health check websocket is closed.
+# Adjusted auth token key in authenticate method to match original server.
+# Refined JSON-RPC response formatting.
+# Added more logging to serve() method, especially around connection lifecycle.
+# Added explicit check for "total_mvnos" or "mvno_count" in health check from db_stats.
+# Added some basic logging configuration in __main__ for early messages.
+# Ensured logger in GhostMCPServer uses config.get_logger("MCP-Server").
+# Added a note on disabling spaCy check in __main__ for GhostConfig for robustness.Tool output for `create_file_with_block`:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Start MCP server
+python3 ghost_mcp_server.py &


### PR DESCRIPTION
Due to issues with the current Python execution environment, this change pivots to a file-creation-only approach.

Key changes:
- Created `ghost_mcp_server_v2.py` which incorporates the original MCP server's core methods into a new structure that includes a `/health` endpoint and other V2 enhancements.
- Created `create_deployment_bundle.sh` to package `ghost_mcp_server_v2.py` (as `ghost_mcp_server.py`), other necessary Python files (`ghost_config.py`, `ghost_db.py`, `mcp_client.py`), `requirements.txt`, and detailed deployment/testing documentation.
- Included `MCP_VERIFICATION_CHECKLIST.md` for operators.
- Included `REMOTE_DEPLOYMENT.md` for guiding remote deployment.
- The `create_deployment_bundle.sh` also bundles an improved `test_mcp_complete.py` and more comprehensive `DEPLOY_INSTRUCTIONS.md`.

This package allows an operator on a functional Python environment to deploy and run the MCP server.